### PR TITLE
Replace DOMNodeInserted with MutationObserver for dynamic content han…

### DIFF
--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -24,12 +24,19 @@
         $R('.redactor-field', {{ redactor_settings() }});
     }
 
-    $(document).on('DOMNodeInserted', function(e) {
-        if ( $(e.target).hasClass('collection-item') ) {
-            initRedactors();
+    initRedactors();
+
+    const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                mutation.addedNodes.forEach(node => {
+                    if (node.nodeType === 1 && $(node).hasClass('collection-item')) {
+                        initRedactors();
+                    }
+                });
+            }
         }
     });
 
-    initRedactors();
+    observer.observe(document.body, { childList: true, subtree: true });
 </script>
-


### PR DESCRIPTION
The `DOMNodeInserted` event is deprecated and no longer supported in recent versions of Chrome (e.g., Chrome 127 and later). This commit updates the code to use `MutationObserver`, which is a modern and recommended way to observe changes in the DOM.

The MutationObserver is set up to monitor changes in the document and specifically look for newly added nodes with the class `collection-item`. When such nodes are detected, the Redactor editor is initialized for these elements.

This change ensures compatibility with newer browser versions and improves performance and reliability when handling dynamic content.

Changes made:
- Replaced `DOMNodeInserted` event listener with a `MutationObserver`.
- Updated the callback function to initialize Redactor editors for dynamically added collection items.